### PR TITLE
Query times by airport coordinates if necessary

### DIFF
--- a/loggingnight.py
+++ b/loggingnight.py
@@ -27,7 +27,13 @@ def total_seconds(td):
 def makedate(datestring):
     return dateparser.parse(datestring).date()
 
-def web_query(url, params=None, headers=None):
+def format_time(t, in_zulu):
+    if in_zulu:
+        return t.strftime('%I%MZ')
+    else:
+        return t.strftime('%I:%M %p')
+
+def web_query(url, params=None, headers=None, exit_on_http_error=True):
     params = params or {}
     headers = headers or {}
 
@@ -37,7 +43,9 @@ def web_query(url, params=None, headers=None):
         r = requests.get(url, headers=headers, params=params, timeout=10)
         debug_print('Final URL of response: %s' % r.url, level=2)
         debug_print('Query time: %f seconds' % total_seconds(r.elapsed), level=2)
-        r.raise_for_status()
+
+        if exit_on_http_error:
+            r.raise_for_status()
 
     except requests.exceptions.Timeout:
         print('Connecting to %s timed out' % url)
@@ -54,7 +62,18 @@ parser.add_argument("-a", "--airport", help="ICAO code for the airport", require
 parser.add_argument("-d", "--date", type=makedate,
                     default=datetime.date.today().isoformat(), help="Date of the flight")
 parser.add_argument("-D", "--debug", action='count')
+parser.add_argument("-o", "--offset", type=float, help="Time zone offset in hours from Zulu, -12.0 to +14.0")
+parser.add_argument("-z", "--zulu", action='store_true', help="Show times in Zulu")
 args = parser.parse_args()
+
+tz = None
+if args.offset is not None and args.zulu == True:
+    print('Specify either a timezone offset (-o/--offset) or Zulu time (-z/--zulu), not both')
+    sys.exit(3)
+elif args.zulu == True:
+    tz = '0'
+elif args.offset is not None:
+    tz = str(args.offset)
 
 airport = web_query(AIRPORTINFO_URL, params={'icao': args.airport})
 debug_print(json.dumps(airport, sort_keys=True, indent=4, separators=(',', ': ')), level=2)
@@ -69,8 +88,25 @@ if not 'location' in airport or not airport['location']:
 # the location is "Chicago / west Chicago, IL"
 location = airport['location'].split('/')[-1]
 
-usno = web_query(USNO_URL, params={'loc': location, 'date': args.date.strftime('%m/%d/%Y')})
-debug_print(json.dumps(usno, sort_keys=True, indent=4, separators=(',', ': ')), level=2)
+date = args.date.strftime('%m/%d/%Y')
+usno = {}
+in_zulu = False
+
+# Skip this query if the user specifies a time zone offset
+if tz is None:
+    usno = web_query(USNO_URL, params={'loc': location, 'date': date}, exit_on_http_error=False)
+    debug_print(json.dumps(usno, sort_keys=True, indent=4, separators=(',', ': ')), level=2)
+    in_zulu = False
+
+# Use airport coordinates if the user wants a particular
+# time zone offset or if USNO doesn't understand the
+# location returned from AIRPORTINFO_URL
+if not 'sundata' in usno or not usno['sundata']:
+    coords = airport['latitude'] + ',' + airport['longitude']
+    offset = tz if tz is not None else '0'
+    usno = web_query(USNO_URL, params={'coords': coords, 'date': date, 'tz': offset})
+    debug_print(json.dumps(usno, sort_keys=True, indent=4, separators=(',', ': ')), level=2)
+    in_zulu = float(offset) == 0
 
 phenTimes = dict((i['phen'], i['time']) for i in usno['sundata'])
 
@@ -78,15 +114,17 @@ sun_set = dateparser.parse(phenTimes['S'])
 end_civil_twilight = dateparser.parse(phenTimes['EC'])
 
 print("Night times for %s on %s" % (airport['name'], args.date.isoformat()))
+if in_zulu and tz is None:
+    print("  - All times are in Zulu; use --offset or --zulu to force a time zone.")
 print("")
-print("%s -- Sun set\nPosition lights required" % sun_set.strftime('%I:%M %p'))
+print("%s -- Sun set\nPosition lights required" % format_time(sun_set, in_zulu))
 print("(14 CFR 91.209)")
 print("")
-print("%s -- End of civil twilight" % end_civil_twilight.strftime('%I:%M %p'))
+print("%s -- End of civil twilight" % format_time(end_civil_twilight, in_zulu))
 print("Logging of night time can start and aircraft must be night equipped")
 print("(14 CFR 61.51(b)(3)(i), 14 CFR 91.205(c), and 14 CFR 1.1)")
 print("")
-print("%s -- One hour after sun set" % (sun_set + ONE_HOUR).strftime('%I:%M %p'))
+print("%s -- One hour after sun set" % format_time(sun_set + ONE_HOUR, in_zulu))
 print("Must be night current to carry passengers and")
 print("logging of night takeoffs and landings can start")
 print("(14 CFR 61.57(b))")


### PR DESCRIPTION
USNO does not always understand the location from airport-data.com, so
rather than just giving up, fall back to querying USNO by the airport
latitude/longitude coordinates.

This fallback query requires a timezone offset that defaults to zero, so
the various times come back in UTC. We do not have a ready source of
airport timezones (e.g., from the FAA Chart Supplement), so this commit
also provides the -o/--offset option to allow the user to provide the
offset.

When the user does want Zulu time, the -z/--zulu option causes times
to look like Zulu times, e.g., 0140Z.