### PR TITLE
Details for Canadian Pilots

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -143,7 +143,10 @@
 <div class="helper">Position lights required (<a href="https://www.law.cornell.edu/cfr/text/14/91.209">14 CFR 91.209(a)</a>)</div>
 <div class="title">End of civil twilight</div>
 <div id="out_end_civil" class="time">{% if result['airport'] is defined %}{{ result['end_civil'] }}{% endif %}</div>
-<div class="helper">Logging of night time can start and aircraft must be night equipped (<a href="https://www.law.cornell.edu/cfr/text/14/61.51">14 CFR 61.51(b)(3)(i)</a>, <a href="https://www.law.cornell.edu/cfr/text/14/91.205">14 CFR 91.205(c)</a>, and <a href="https://www.law.cornell.edu/cfr/text/14/1.1">14 CFR 1.1</a>)</div>
+<div class="helper">Logging of night time can start and aircraft must be night equipped (<a href="https://www.law.cornell.edu/cfr/text/14/61.51">14 CFR 61.51(b)(3)(i)</a>, <a href="https://www.law.cornell.edu/cfr/text/14/91.205">14 CFR 91.205(c)</a>, and <a href="https://www.law.cornell.edu/cfr/text/14/1.1">14 CFR 1.1</a>)
+<br>
+Canadian Pilots: Must have a night rating (<a href="http://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/FullText.html#s-401.43">CAR 401.43</a>), be night equipped (<a href="http://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/FullText.html#s-605.16">CAR 605.16<a>, <a href="http://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/FullText.html#s-605.17">605.17</a>), and can start logging night time (<a href="http://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/FullText.html#s-101.01">CAR 101.01</a>)
+</div>
 <div class="title">One hour after sun set</div>
 <div id="out_one_hour" class="time">{% if result['airport'] is defined %}{{ result['one_hour'] }}{% endif %}</div>
 <div class="helper">Must be night current to carry passengers and logging of night takeoffs and landings can start (<a href="https://www.law.cornell.edu/cfr/text/14/61.57">14 CFR 61.57(b)</a>)</div>


### PR DESCRIPTION
The rules for flying at Night for Canadian pilots are a little simpler, in that everything happens between civil night twilight and civil dawn twilight.

This pull requests adds the relevant details and links to the Canadian Aviation Regulations (CAR) to the index template. 